### PR TITLE
Mehrere URL's von der Suche ausschließen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,7 @@ Danach aktivierst du das Plugin in der Konfigurationsdatei.
         enable:
             - simplesearch
 
-## Konfiguration
-
-Du kannst einzelne URL's von der Suche ausschließen.
-
-Ergänze dazu die Konfigurationsdatei:
-
-    config:
-        simplesearch:
-            excluded_urls: ['@plugin/adminpanel/pages/adminpanel.html', '@plugin/simplesearch/pages/suche.html' ]
+Du kannst einzelne Seiten mit der Seiteneigenschaft "no_search: 1" von der Suche ausschließen.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Danach aktivierst du das Plugin in der Konfigurationsdatei.
         enable:
             - simplesearch
 
+## Konfiguration
+
+Du kannst einzelne URL's von der Suche ausschließen.
+
+Ergänze dazu die Konfigurationsdatei:
+
+    config:
+        simplesearch:
+            excluded_urls: ['@plugin/adminpanel/pages/adminpanel.html', '@plugin/simplesearch/pages/suche.html' ]
+
 ## Demo
 
 <http://getherbie.org/suche?query=herbie>

--- a/SimplesearchPlugin.php
+++ b/SimplesearchPlugin.php
@@ -110,7 +110,6 @@ class SimplesearchPlugin extends Herbie\Plugin
         $max = 100;
         $results = [];
 
-        $excludedUrls = $this->getExcludedUrls();
         $usePageCache = $this->config('cache.page.enable', false);
         $usePageCache &= $this->config('plugins.config.simplesearch.use_page_cache', false);
 
@@ -119,7 +118,7 @@ class SimplesearchPlugin extends Herbie\Plugin
         $appendIterator->append($this->app['posts']->getIterator());
 
         foreach ($appendIterator as $item) {
-            if ($i>$max || empty($item->title) || in_array($item->path, $excludedUrls)) {
+            if ($i>$max || empty($item->title) || !empty($item->no_search)) {
                 continue;
             }
             $data = $this->loadPageData($item, $usePageCache);
@@ -148,16 +147,5 @@ class SimplesearchPlugin extends Herbie\Plugin
             }
         }
         return false;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getExcludedUrls()
-    {
-        return $this->config(
-            'plugins.config.simplesearch.excluded_urls',
-            ['@plugin/adminpanel/pages/search.html']
-        );
     }
 }

--- a/SimplesearchPlugin.php
+++ b/SimplesearchPlugin.php
@@ -110,7 +110,7 @@ class SimplesearchPlugin extends Herbie\Plugin
         $max = 100;
         $results = [];
 
-        $pathAlias = $this->getPathAlias();
+        $excludedUrls = $this->getExcludedUrls();
         $usePageCache = $this->config('cache.page.enable', false);
         $usePageCache &= $this->config('plugins.config.simplesearch.use_page_cache', false);
 
@@ -119,7 +119,7 @@ class SimplesearchPlugin extends Herbie\Plugin
         $appendIterator->append($this->app['posts']->getIterator());
 
         foreach ($appendIterator as $item) {
-            if ($i>$max || empty($item->title) || $item->path == $pathAlias) {
+            if ($i>$max || empty($item->title) || in_array($item->path, $excludedUrls)) {
                 continue;
             }
             $data = $this->loadPageData($item, $usePageCache);
@@ -151,13 +151,13 @@ class SimplesearchPlugin extends Herbie\Plugin
     }
 
     /**
-     * @return string
+     * @return array
      */
-    protected function getPathAlias()
+    protected function getExcludedUrls()
     {
         return $this->config(
-            'plugins.config.simplesearch.page.search',
-            '@plugin/simplesearch/pages/search.html'
+            'plugins.config.simplesearch.excluded_urls',
+            ['@plugin/adminpanel/pages/search.html']
         );
     }
 }


### PR DESCRIPTION
Mehrere URL's können als Array in der config.yml angegeben werden, die von dem SimpleSearch-Plugin irgnoriert werden.
